### PR TITLE
slack notification lambda, iam policy update, sns...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # generated zip files
 *.zip
+
+node_modules

--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,0 +1,56 @@
+# Alerts Lambda
+resource "aws_lambda_permission" "cloudwatch_alerts_lambda" {
+  statement_id  = "AllowExecutionFromSNS"
+  action        = "lambda:InvokeFunction"
+  function_name = "${aws_lambda_function.cloudwatch_alerts_lambda.arn}"
+  principal     = "sns.amazonaws.com"
+  source_arn    = "${aws_sns_topic.cloudwatch.arn}"
+}
+
+resource "aws_lambda_function" "cloudwatch_alerts_lambda" {
+  filename         = "${data.archive_file.cloudwatch_alerts_lambda_zip.output_path}"
+  function_name    = "cloudwatch_alerts"
+  role             = "${aws_iam_role.role.arn}"
+  handler          = "cloudwatchSlackAlerts.handler"
+  runtime          = "nodejs8.10"
+  source_code_hash = "${data.archive_file.cloudwatch_alerts_lambda_zip.output_base64sha256}"
+
+  environment {
+    variables = {
+      UNENCRYPTED_HOOK_URL = ""
+    }
+  }
+}
+
+data "archive_file" "cloudwatch_alerts_lambda_zip" {
+  type        = "zip"
+  output_path = "./cloudwatchSlackAlerts.zip"
+  source_dir  = "../cloudwatch_alerts"
+}
+
+# SNS
+resource "aws_sns_topic" "cloudwatch" {
+  name = "cloudwatch_alarms"
+}
+resource "aws_sns_topic_subscription" "cloudwatch" {
+  topic_arn = "${aws_sns_topic.cloudwatch.arn}"
+  protocol  = "lambda"
+  endpoint  = "${aws_lambda_function.cloudwatch_alerts_lambda.arn}"
+}
+
+# IAM
+resource "aws_iam_role_policy" "cloudwatch_logs" {
+  role = "${aws_iam_role.role.name}"
+
+  policy = <<EOF
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["logs:*"],
+      "Resource": ["*"]
+    }
+  ]
+}
+EOF
+}

--- a/cloudwatch_alerts/cloudwatchSlackAlerts.js
+++ b/cloudwatch_alerts/cloudwatchSlackAlerts.js
@@ -1,0 +1,129 @@
+const url = require('url');
+const https = require('https');
+
+let hookUrl;
+
+const postMessage = (message, callback) => {
+  const body = JSON.stringify(message);
+  const options = url.parse(hookUrl);
+  options.method = 'POST';
+  options.headers = {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(body),
+  };
+
+  const postReq = https.request(options, (res) => {
+    const chunks = [];
+    res.setEncoding('utf8');
+    res.on('data', chunk => chunks.push(chunk));
+    res.on('end', () => {
+      const body = chunks.join('');
+      if (callback) {
+        callback({
+          body,
+          statusCode: res.statusCode,
+          statusMessage: res.statusMessage,
+        });
+      }
+    });
+    return res;
+  });
+
+  postReq.write(body);
+  postReq.end();
+};
+
+const handleCloudWatch = (event) => {
+  const timestamp = (new Date(event.Records[0].Sns.Timestamp)).getTime() / 1000;
+  const message = JSON.parse(event.Records[0].Sns.Message);
+  const region = event.Records[0].EventSubscriptionArn.split(':')[3];
+  const subject = 'AWS CloudWatch Notification';
+  const alarmName = message.AlarmName;
+  const metricName = message.Trigger.MetricName;
+  const oldState = message.OldStateValue;
+  const newState = message.NewStateValue;
+  const alarmReason = message.NewStateReason;
+  const trigger = message.Trigger;
+  let color = 'warning';
+
+  if (message.NewStateValue === 'ALARM') {
+    color = 'danger';
+  } else if (message.NewStateValue === 'OK') {
+    color = 'good';
+  }
+
+  return {
+    text: `*${subject}*`,
+    attachments: [
+      {
+        color,
+        fields: [
+          { title: 'Alarm Name', value: alarmName, short: true },
+          { title: 'Alarm Description', value: alarmReason, short: false },
+          {
+            title: 'Trigger',
+            value: `${trigger.Statistic} ${
+              metricName} ${
+              trigger.ComparisonOperator} ${
+              trigger.Threshold} for ${
+              trigger.EvaluationPeriods} period(s) of ${
+              trigger.Period} seconds.`,
+            short: false,
+          },
+          { title: 'Old State', value: oldState, short: true },
+          { title: 'Current State', value: newState, short: true },
+          {
+            title: 'Link to Alarm',
+            value: `https://console.aws.amazon.com/cloudwatch/home?region=${region}#alarm:alarmFilter=ANY;name=${alarmName}`,
+            short: false,
+          },
+        ],
+        ts: timestamp,
+      },
+    ],
+  };
+};
+
+const processEvent = (event, context) => {
+  console.log(`sns received:${JSON.stringify(event, null, 2)}`);
+  let slackMessage = null;
+  const eventSnsMessageRaw = event.Records[0].Sns.Message;
+  let eventSnsMessage = null;
+
+  try {
+    eventSnsMessage = JSON.parse(eventSnsMessageRaw);
+  } catch (e) {
+    console.log(e);
+  }
+
+  if (eventSnsMessage && 'AlarmName' in eventSnsMessage && 'AlarmDescription' in eventSnsMessage) {
+    console.log('processing cloudwatch notification');
+    slackMessage = handleCloudWatch(event, context);
+  }
+
+  postMessage(slackMessage, (response) => {
+    if (response.statusCode < 400) {
+      console.info('message posted successfully');
+      context.succeed();
+    } else if (response.statusCode < 500) {
+      console.error(`error posting message to slack API: ${response.statusCode} - ${response.statusMessage}`);
+      // Don't retry because the error is due to a problem with the request
+      context.succeed();
+    } else {
+      // Let Lambda retry
+      context.fail(`server error when processing message: ${response.statusCode} - ${response.statusMessage}`);
+    }
+  });
+};
+
+exports.handler = (event, context) => {
+  console.log(event);
+  if (hookUrl) {
+    processEvent(event, context);
+  } else if (process.env.UNENCRYPTED_HOOK_URL) {
+    hookUrl = process.env.UNENCRYPTED_HOOK_URL;
+    processEvent(event, context);
+  } else {
+    context.fail('hook url has not been set.');
+  }
+};


### PR DESCRIPTION
This PR should modify the existing IAM role to allow cloudwatch logs, adds SNS and a Lambda for sending slack notifications.

In order for this to work you must: 

- provide a slack webhook URL
- create alarms with the aws dashboard