### PR TITLE
cloudwatch logging on lambda

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -1,0 +1,16 @@
+# IAM
+resource "aws_iam_role_policy" "cloudwatch_logs" {
+  role = "${aws_iam_role.role.name}"
+
+  policy = <<EOF
+{
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["logs:*"],
+      "Resource": ["*"]
+    }
+  ]
+}
+EOF
+}

--- a/examples/build/lambdaClass.js
+++ b/examples/build/lambdaClass.js
@@ -7,5 +7,6 @@ exports.handler = (event, context, callback) => {
     },
     body: JSON.stringify(event.path),
   };
+  console.log('event', event)
   callback(null, response);
 };


### PR DESCRIPTION
### Prereqs:

- aws-cli

- an aws-vault profile set up (see the readme in this repo: https://github.com/autotelic/schema-infrastructure )

### To test:

cd into examples/simple

```
$ aws-vault exec <YOUR_PROFILE> -- terraform init
$ aws-vault exec <YOUR_PROFILE> -- terraform plan
$ aws-vault exec <YOUR_PROFILE> -- terraform apply
$ curl $(terraform output invoke_url)/foo
```

verify log stream is there

```
$ aws-vault exec <YOUR_PROFILE> -- aws logs describe-log-streams --log-group-name '/aws/lambda/lambda_func'
```

then you can check the logs by inserting the stream name here:

```
$ aws-vault exec <YOUR_PROFILE> -- aws logs get-log-events --log-group-name '/aws/lambda/lambda_func' --log-stream-name '2018/11/23/[$LATEST]XXXXXXXXXXXXXXXXXX'
```

(alternatively: navigate to services/cloudwatch and check the logs. (Click /aws/lambda/lambdaClass then the most recent Log Stream))

### Teardown
`$ aws-vault exec <YOUR_PROFILE> -- terraform destroy`
