### PR TITLE
global api gateway cloudwatch role

### DIFF
--- a/apigw_cloudwatch.tf
+++ b/apigw_cloudwatch.tf
@@ -1,0 +1,50 @@
+# Below creates a global role for API gateway logging
+resource "aws_api_gateway_account" "api_gateway_logging" {
+  cloudwatch_role_arn = "${aws_iam_role.cloudwatch.arn}"
+}
+
+resource "aws_iam_role" "cloudwatch" {
+  name = "api_gateway_cloudwatch_global"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "apigateway.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "cloudwatch" {
+  name = "default"
+  role = "${aws_iam_role.cloudwatch.id}"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
+                "logs:PutLogEvents",
+                "logs:GetLogEvents",
+                "logs:FilterLogEvents"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}


### PR DESCRIPTION
## Summary:

Small update to enable cloudwatch logging for API Gateway.

## Prereqs:

- aws-cli

- an aws-vault profile set up (see the readme in this repo: https://github.com/autotelic/schema-infrastructure )

## To test:
- cd into examples/simple

```
$ aws-vault exec <YOUR_PROFILE> -- terraform init
$ aws-vault exec <YOUR_PROFILE> -- terraform plan
$ aws-vault exec <YOUR_PROFILE> -- terraform apply
```

- to see if it has taken effect, go to this link ( https://us-west-2.console.aws.amazon.com/apigateway/home?region=us-west-2#/settings  ) and check to see if you have "api_gateway_cloudwatch_global" as your CloudWatch log role ARN.

- curl the lambda
```
$ curl $(terraform output invoke_url)/foo
```

- check to see if log stream is created for api gateway execution logs are created by navigating to: https://us-west-2.console.aws.amazon.com/cloudwatch/home?region=us-west-2#logs:

## Teardown
```
$ aws-vault exec <YOUR_PROFILE> -- terraform destroy
```