### PR TITLE
switched hard coded name for IAM role to come from vars

### DIFF
--- a/apigw_cloudwatch.tf
+++ b/apigw_cloudwatch.tf
@@ -4,7 +4,7 @@ resource "aws_api_gateway_account" "api_gateway_logging" {
 }
 
 resource "aws_iam_role" "cloudwatch" {
-  name = "api_gateway_cloudwatch_global"
+  name = "${var.cloudwatch_iam_role_name}"
 
   assume_role_policy = <<EOF
 {

--- a/vars.tf
+++ b/vars.tf
@@ -37,3 +37,7 @@ variable "lambda_zip_source_dir" {
 variable "api_gateway_lambda_iam_role" {
   description = "Name of the IAM role for lambda on AWS"
 }
+
+variable "cloudwatch_iam_role_name" {
+  description = "Name of the IAM role for cloudwatch on AWS"
+}


### PR DESCRIPTION
Was having issues using this module as it tries to create the same IAM role again in `apigw_cloudwatch.tf` . Switched from being a hard-coded value to now being pulled from vars. 

## Issue Tracking 
Resolves #6 